### PR TITLE
Fix table column width

### DIFF
--- a/main/http_server/axe-os/src/app/components/scoreboard/scoreboard.component.html
+++ b/main/http_server/axe-os/src/app/components/scoreboard/scoreboard.component.html
@@ -7,7 +7,6 @@
                 <thead>
                     <tr>
                         <th *ngFor="let field of [
-
                             { label: 'Rank', name: 'rank' },
                             { label: 'Difficulty', name: 'difficulty' },
                             { label: 'Job ID', name: 'job_id' },
@@ -16,9 +15,9 @@
                             { label: 'Nonce', name: 'nonce' },
                             { label: 'Version Bits', name: 'version_bits' }
                         ]" class="text-500 font-medium">
-                            <div class="flex align-items-center cursor-pointer select-none" (click)="sortBy(field.name)">
+                            <div class="flex align-items-center cursor-pointer select-none relative" (click)="sortBy(field.name)">
                                 <span>{{field.label}}</span>
-                                <i class="pi text-xs ml-2" [ngClass]="{
+                                <i class="pi text-xs ml-2 absolute right-0" [ngClass]="{
                                     'pi-sort-up-fill': sortField === field.name && sortDirection === 'asc',
                                     'pi-sort-down-fill': sortField === field.name && sortDirection === 'desc'
                                 }"></i>
@@ -33,7 +32,7 @@
                             <i class="pi pi-trophy" *ngIf="entry.rank < 3" [ngStyle]="{
                                 'color': entry.rank === 0 ? 'gold' : entry.rank === 1 ? 'silver' : 'peru'
                             }"></i>
-                            <span *ngIf="entry.rank >= 3" class="text-500 text-xs">{{ entry.rank + 1 }}</span> 
+                            <span *ngIf="entry.rank >= 3" class="text-500 text-xs">{{ entry.rank + 1 }}</span>
                         </td>
                         <td pTooltip="{{ entry.difficulty }}" tooltipPosition="top" class="text-900">{{ entry.difficulty | suffix }}</td>
                         <td class="code">{{ entry.job_id }}</td>

--- a/main/http_server/axe-os/src/app/components/scoreboard/scoreboard.component.scss
+++ b/main/http_server/axe-os/src/app/components/scoreboard/scoreboard.component.scss
@@ -6,7 +6,6 @@ td {
     padding: 0 0.5rem 0.5rem;
     white-space: nowrap;
     text-align: left;
-    vertical-align: top;
 
     &:first-child {
         padding-left: 0;
@@ -17,10 +16,6 @@ td {
 }
 td {
     padding-top: 0.5rem;
-
-    p {
-        line-height: 1.4;
-    }
 }
 tbody tr {
     border-top: 1px solid var(--surface-border);


### PR DESCRIPTION
To solve the problem with the jumping column width, we need to position the sort arrow absolutely. Here is one possible solution. If we use it, I will also integrate it into https://github.com/bitaxeorg/ESP-Miner/pull/1231

<img width="984" height="277" alt="Screenshot" src="https://github.com/user-attachments/assets/3f4d703c-30cb-4c06-8d10-e6b0bb6512bd" />
