### PR TITLE
Fix table column min-width

### DIFF
--- a/main/http_server/axe-os/src/app/components/scoreboard/scoreboard.component.html
+++ b/main/http_server/axe-os/src/app/components/scoreboard/scoreboard.component.html
@@ -16,7 +16,7 @@
                             { label: 'Version Bits', name: 'version_bits' }
                         ]" class="text-500 font-medium">
                             <div class="flex align-items-center cursor-pointer select-none relative" (click)="sortBy(field.name)">
-                                <span>{{field.label}}</span>
+                                <span class="pr-3">{{field.label}}</span>
                                 <i class="pi text-xs ml-2 absolute right-0" [ngClass]="{
                                     'pi-sort-up-fill': sortField === field.name && sortDirection === 'asc',
                                     'pi-sort-down-fill': sortField === field.name && sortDirection === 'desc'


### PR DESCRIPTION
I checked the layout on several devices. We need to add some placeholder spacing between column label and the arrow icon in case the column width is too small.

Before
<img width="787" height="314" alt="Before" src="https://github.com/user-attachments/assets/99816abb-ca69-448e-ab6f-bc0e1f95f56f" />

After
<img width="783" height="312" alt="After" src="https://github.com/user-attachments/assets/b794ed15-7b4f-49d7-8d02-cd563df40c8f" />

