### PR TITLE
Dashboard cards refactoring

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -1,5 +1,11 @@
 <ng-template #noValue>--</ng-template>
 
+<ng-template #powerFault>
+    <span class="text-red-500">
+        Not available - Power fault
+    </span>
+</ng-template>
+
 <ng-container *ngIf="info$ | async as info">
     <ng-container *ngFor="let message of messages">
         <p-message
@@ -17,36 +23,100 @@
         <div class="col-12 md:col-6 xl:col-3">
             <div class="card mb-0">
                 <div class="flex flex-column justify-content-between">
-                    <span class="block text-500 font-medium mb-3">Hashrate</span>
+                    <span class="block text-lg font-medium mb-3">Hashrate</span>
 
                     <ng-container *ngIf="!info.power_fault; else powerFault">
-                        <div class="flex align-items-baseline gap-2 mb-3">
-                            <span class="text-900 font-medium text-2xl">
+                        <div class="flex align-items-center justify-content-between gap-2 mb-3">
+                            <span class="text-900 font-medium text-2xl white-space-nowrap">
                                 {{info.hashRate | hashSuffix}}
                             </span>
-                            <span class="text-500 text-xs">
-                                <tooltip-text-icon
-                                    text="Error: {{info.errorPercentage | number: '1.2-2'}}%"
-                                    tooltip="Hash error percentage as reported by the ASIC. A small amount of errors every few seconds is normal. Frequency changes, agressive overclocking, undervoltage or a bad power supply can significantly increase the error rate."
-                                />
+                            <table class="text-xs">
+                                <thead>
+                                    <tr>
+                                        <th class="p-0 text-400 font-normal line-height-1 cursor-pointer" pTooltip="Hash error percentage as reported by the ASIC. A small amount of errors every few seconds is normal. Frequency changes, agressive overclocking, undervoltage or a bad power supply can significantly increase the error rate.">
+                                            Error
+                                        </th>
+                                        <th *ngIf="info.expectedHashrate" class="p-0 pl-3 text-400 font-normal line-height-1">
+                                            Expected
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td class="p-0 text-center text-800 line-height-1">
+                                            {{info.errorPercentage | number: '1.2-2'}}%
+                                        </td>
+                                        <td class="p-0 pl-3 text-center text-800 line-height-1 white-space-nowrap" *ngIf="info.expectedHashrate">
+                                            {{info.expectedHashrate | hashSuffix: { tickmark: true } }}
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <table class="px-1 border-1 border-50 border-round-xs">
+                            <thead>
+                                <tr>
+                                    <th class="p-0 text-500 font-normal line-height-1">1m</th>
+                                    <th class="p-0 text-500 font-normal line-height-1">10m</th>
+                                    <th class="p-0 text-500 font-normal line-height-1">1h</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td class="p-0 text-center text-green-500 font-medium">
+                                        {{info.hashRate_1m | hashSuffix}}
+                                    </td>
+                                    <td class="p-0 text-center text-green-500 font-medium">
+                                        {{info.hashRate_10m | hashSuffix}}
+                                    </td>
+                                    <td class="p-0 text-center text-green-500 font-medium">
+                                        {{info.hashRate_1h | hashSuffix}}
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </ng-container>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 md:col-6 xl:col-3">
+            <div class="card mb-0">
+                <div class="flex flex-column justify-content-between">
+                    <span class="block text-lg font-medium mb-3">Efficiency</span>
+
+                    <ng-container *ngIf="!info.power_fault; else powerFault">
+                        <div class="flex align-items-center justify-content-between gap-2 mb-3">
+                            <span class="text-900 font-medium text-2xl white-space-nowrap">
+                                {{getEfficiency(info) | number: '1.2-2'}} J/Th
                             </span>
+                            <table class="text-xs">
+                                <thead>
+                                    <tr>
+                                        <th class="p-0 text-400 font-normal line-height-1">
+                                            Expected
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td class="p-0 text-center text-800 line-height-1 white-space-nowrap">
+                                            {{getExpectedEfficiency(info) | number: '1.2-2'}} J/Th
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
                         </div>
 
                         <div>
-                            1m: <span class="text-green-500 font-medium">{{info.hashRate_1m | hashSuffix}}</span>
-                            10m: <span class="text-green-500 font-medium">{{info.hashRate_10m | hashSuffix}}</span>
-                            1h: <span class="text-green-500 font-medium">{{info.hashRate_1h | hashSuffix}}</span>
-                        </div>
-                        <div class="text-500 text-xs" *ngIf="info.expectedHashrate">
-                            Expected: {{info.expectedHashrate | hashSuffix: { tickmark: true } }}
+                            <span class="text-green-500 font-medium white-space-nowrap">
+                                {{getEfficiencyAverage() | number: '1.2-2'}} J/Th
+                            </span>
+                            <span class="text-500">
+                                Average
+                            </span>
                         </div>
                     </ng-container>
-
-                    <ng-template #powerFault>
-                        <span class="text-red-500">
-                            Not available - Power fault
-                        </span>
-                    </ng-template>
                 </div>
             </div>
         </div>
@@ -54,36 +124,9 @@
             <div class="card mb-0">
                 <div class="flex justify-content-between mb-3">
                     <div>
-                        <span class="block text-500 font-medium mb-3">Efficiency</span>
-                        <div class="text-900 font-medium text-2xl flex align-items-center gap-2">
-                            <span *ngIf="!info.power_fault">
-                                {{getEfficiency(info) | number: '1.2-2'}} J/Th
-                            </span>
-                            <span *ngIf="info.power_fault" class="text-red-500">
-                                Not available - Power fault
-                            </span>
-                        </div>
-                    </div>
-                </div>
-
-                <ng-container *ngIf="!info.power_fault">
-                    Average:
-                    <span class="text-green-500 font-medium">
-                        {{getEfficiencyAverage() | number: '1.2-2'}} J/Th
-                    </span>
-                </ng-container>
-
-                <div class="text-500 text-xs" *ngIf="!info.power_fault && info.expectedHashrate">
-                    Expected: {{getExpectedEfficiency(info) | number: '1.2-2'}} J/Th
-                </div>
-            </div>
-        </div>
-        <div class="col-12 md:col-6 xl:col-3">
-            <div class="card mb-0">
-                <div class="flex justify-content-between mb-3">
-                    <div>
-                        <span class="block text-500 font-medium mb-3">Shares</span>
-                        <div class="text-900 font-medium text-2xl">{{info.sharesAccepted | number: '1.0-0'}}
+                        <span class="block text-lg font-medium mb-3">Shares</span>
+                        <div class="text-900 font-medium text-2xl">
+                            {{info.sharesAccepted | number: '1.0-0'}}
                         </div>
                     </div>
                 </div>
@@ -112,8 +155,9 @@
             <div class="card mb-0">
                 <div class="flex justify-content-between mb-3">
                     <div>
-                        <span class="block text-500 font-medium mb-3">Best Difficulty</span>
-                        <div class="text-900 font-medium text-2xl">{{info.bestDiff | diffSuffix}}
+                        <span class="block text-lg font-medium mb-3">Best Difficulty</span>
+                        <div class="text-900 font-medium text-2xl">
+                            {{info.bestDiff | diffSuffix}}
                             <span class="text-500 text-lg">all-time best</span>
                         </div>
                     </div>

--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -46,7 +46,7 @@
                                         <td class="p-0 text-center text-800 line-height-1">
                                             {{info.errorPercentage | number: '1.2-2'}}%
                                         </td>
-                                        <td class="p-0 pl-3 text-center text-800 line-height-1 white-space-nowrap" *ngIf="info.expectedHashrate">
+                                        <td *ngIf="info.expectedHashrate" class="p-0 pl-3 text-center text-800 line-height-1 white-space-nowrap">
                                             {{info.expectedHashrate | hashSuffix: { tickmark: true } }}
                                         </td>
                                     </tr>
@@ -57,21 +57,15 @@
                         <table class="px-1 border-1 border-50 border-round-xs">
                             <thead>
                                 <tr>
-                                    <th class="p-0 text-500 font-normal line-height-1">1m</th>
-                                    <th class="p-0 text-500 font-normal line-height-1">10m</th>
-                                    <th class="p-0 text-500 font-normal line-height-1">1h</th>
+                                    <th *ngFor="let i of hashrateAverages" class="p-0 text-500 font-normal line-height-1">
+                                        {{i.label}}
+                                    </th>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td class="p-0 text-center text-green-500 font-medium">
-                                        {{info.hashRate_1m | hashSuffix}}
-                                    </td>
-                                    <td class="p-0 text-center text-green-500 font-medium">
-                                        {{info.hashRate_10m | hashSuffix}}
-                                    </td>
-                                    <td class="p-0 text-center text-green-500 font-medium">
-                                        {{info.hashRate_1h | hashSuffix}}
+                                    <td *ngFor="let i of hashrateAverages" class="p-0 text-center text-green-500 font-medium">
+                                        {{ info[i.key] | hashSuffix }}
                                     </td>
                                 </tr>
                             </tbody>

--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -71,6 +71,12 @@ export class HomeComponent implements OnInit, OnDestroy {
   public activePoolLabel!: PoolLabel;
   public responseTime!: number;
 
+  public hashrateAverages: { label: string, key: 'hashRate_1m' | 'hashRate_10m' | 'hashRate_1h' }[] = [
+    { label: '1m', key: 'hashRate_1m' },
+    { label: '10m', key: 'hashRate_10m' },
+    { label: '1h', key: 'hashRate_1h' }
+  ];
+
   @ViewChild('chart')
   private chart?: UIChart
 


### PR DESCRIPTION
Rework dashboard cards for new hashrate averages.
Added a little bit more space between `error` and `expected` columns.

**Desktop**
<img width="2864" height="1896" alt="Desktop" src="https://github.com/user-attachments/assets/0b7554f7-2f69-4a1a-a781-e459bb6a7953" />


**Mobile**
<img width="406" alt="Mobile" src="https://github.com/user-attachments/assets/f6d81303-4f75-44ea-a169-baf4a8058466" />
